### PR TITLE
PLANET-3841: Columns block: font (and size) changing when adding paragraph in block descriptions 

### DIFF
--- a/src/layout/_page-section.scss
+++ b/src/layout/_page-section.scss
@@ -6,7 +6,7 @@
 // <header>
 //   <h2 class="page-section-header">Block Title</h2>
 // </header>
-// <p class="page-section-description">Description Text</p>
+// <div class="page-section-description">Description Text</div>
 //
 // Styleguide Layout.page-section
 .page-section-header {


### PR DESCRIPTION
This is just to update the styleguide to reflect the changes in: https://github.com/greenpeace/planet4-plugin-blocks/pull/618