### PR TITLE
PLANET-4241 - Eliminate Header padding when there is no content

### DIFF
--- a/src/layout/_page-header.scss
+++ b/src/layout/_page-header.scss
@@ -61,11 +61,7 @@
   }
 
   &.page-header-hidden {
-    padding: $menu-height-small 0 0 0;
-
-    @include medium-and-up {
-      padding: $menu-height-large 0 0 0;
-    }
+    padding: 0 !important;
   }
 
   .container > *:not(.row) {


### PR DESCRIPTION
After greenpeace/planet4-master-theme@022b634dcaa7e1797d53cd513b369a502a4f4d6c page header markup is visible even when there is no header content. So this eliminates its padding. 

I added the `!important` since we have some more explicit campaign overrides.