### PR TITLE
Remove display flex property

### DIFF
--- a/src/layout/_cookies.scss
+++ b/src/layout/_cookies.scss
@@ -40,6 +40,7 @@
     line-height: 1.5rem;
     width: 100%;
     padding-right: $space-md;
+    display: block;
 
     html[dir="rtl"] & {
       padding-right: 0;
@@ -49,7 +50,6 @@
     @include medium-and-up {
       font-size: $font-size-xs;
       margin-bottom: 0;
-      display: flex;
       vertical-align: middle;
     }
     @include large-and-up {


### PR DESCRIPTION
This flex property was probably introduced by mistake when removing a few lines from the previous commit (which also had color changes).

Causes this:

![image](https://user-images.githubusercontent.com/340766/67301719-30be7180-f4c6-11e9-8c11-82c330ec192d.png)
