### PR TITLE
PLANET-4357 Enable skewed header background for the plastic campaign

### DIFF
--- a/src/campaigns/themes/_theme_antarctic.scss
+++ b/src/campaigns/themes/_theme_antarctic.scss
@@ -40,6 +40,10 @@ body.theme-antarctic {
     }
   }
 
+  .skewed-overlay {
+    display: none;
+  }
+
   .page-section-header {
     @include page-section-header($sanctuary, $antarctic-blue);
   }

--- a/src/campaigns/themes/_theme_arctic.scss
+++ b/src/campaigns/themes/_theme_arctic.scss
@@ -45,6 +45,10 @@ body.theme-arctic {
     }
   }
 
+  .skewed-overlay {
+    display: none;
+  }
+
   .page-section-header {
     @include page-section-header($save-the-arctic, $arctic-blue, $bold);
   }

--- a/src/campaigns/themes/_theme_climate.scss
+++ b/src/campaigns/themes/_theme_climate.scss
@@ -69,6 +69,10 @@ body.theme-climate {
     }
   }
 
+  .skewed-overlay {
+    display: none;
+  }
+
   .page-section-header {
     @include page-section-header($jost, $dark-shade-black, 800, 2rem);
     margin-bottom: $space-md;

--- a/src/campaigns/themes/_theme_forest.scss
+++ b/src/campaigns/themes/_theme_forest.scss
@@ -38,6 +38,10 @@ body.theme-forest {
     }
   }
 
+  .skewed-overlay {
+    display: none;
+  }
+
   .page-section-header {
     @include page-section-header($kanit, $forest-black, $extra-bold, 3.75rem);
   }

--- a/src/campaigns/themes/_theme_oceans.scss
+++ b/src/campaigns/themes/_theme_oceans.scss
@@ -53,6 +53,10 @@ body.theme-oceans {
     }
   }
 
+  .skewed-overlay {
+    display: none;
+  }
+
   .page-section-header {
     @include page-section-header($montserrat, $oceans-blue, $extra-bold, 3.75rem);
   }

--- a/src/campaigns/themes/_theme_oil.scss
+++ b/src/campaigns/themes/_theme_oil.scss
@@ -55,6 +55,10 @@ body.theme-oil {
     }
   }
 
+  .skewed-overlay {
+    display: none;
+  }
+
   .page-section-header {
     @include page-section-header($anton);
   }

--- a/src/campaigns/themes/_theme_plastic.scss
+++ b/src/campaigns/themes/_theme_plastic.scss
@@ -52,48 +52,21 @@ body.theme-plastic {
   }
 
   .page-header {
-    @include page-header-block($montserrat);
-
-    overflow: hidden;
+    .page-header-title,
+    .page-header-subtitle {
+      color: $plastics-blue;
+      font-family: $montserrat;
+      text-transform: uppercase;
+    }
 
     .page-header-title {
       font-size: 3.125rem;
       line-height: 4.375rem;
-      color: white;
     }
 
     .page-header-subtitle {
       font-size: $font-size-xl;
       line-height: 2.5rem;
-      color: white;
-    }
-
-    .page-header-content {
-      color: white;
-    }
-
-    .page-header-background {
-      bottom: 0;
-
-      @include small-and-up {
-        left: -50vw;
-        right: -50vw;
-        margin: auto;
-
-        img {
-          min-height: 100vh;
-          width: auto;
-          max-width: none;
-          min-width: 100vw;
-        }
-      }
-
-      &:after {
-        background: linear-gradient(to top left, white, $plastics-blue);
-        bottom: 0;
-        height: 100%;
-        opacity: 0.8;
-      }
     }
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4357

This is a mirror of greenpeace/planet4-plugin-blocks#665 so the changes are there after the Gutenberg switch.