### PR TITLE
PLANET-4674 Make table block respect color settings.

### DIFF
--- a/src/layout/_tables.scss
+++ b/src/layout/_tables.scss
@@ -37,12 +37,15 @@
       }
     }
 
-    tr:nth-child(odd) {
-      background-color: $table-odd;
-    }
+    // Table having `.has-background` class means that a background color was explicitly set on the block.
+    &:not(.has-background) {
+      tr:nth-child(odd) {
+        background-color: $table-odd;
+      }
 
-    tr:nth-child(even) {
-      background-color: $table-even;
+      tr:nth-child(even) {
+        background-color: $table-even;
+      }
     }
   }
 }


### PR DESCRIPTION
* only set the background color of rows if no color was specified in the
block settings (in which case it will have `has-background` class.