### PR TITLE
PLANET-4740: CSS: Remove :not(#hidecookie) rule

### DIFF
--- a/src/layout/_cookies.scss
+++ b/src/layout/_cookies.scss
@@ -24,10 +24,12 @@
   min-height: 80px;
   flex-direction: column;
   padding: 36px;
+  background-size: cover;
 
   @include medium-and-up {
     flex-direction: row;
     padding: 24px 36px;
+    background-size: auto;
   }
 
   > div {
@@ -78,6 +80,7 @@
     box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
     background-color: transparentize($white, .2);
     margin-bottom: 0;
+    color: $dark-blue;
 
     @include medium-and-up {
       width: 150px;
@@ -90,6 +93,7 @@
     }
 
     &:hover {
+      color: $white;
       border-color: $dark-blue;
       background-color: $dark-blue;
     }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4740

Master Theme PR: https://github.com/greenpeace/planet4-master-theme/pull/1009 
Blocks Plugin PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/215

Note: this also fixes a background issue in mobile:

<img width="369" alt="Captura de pantalla 2020-02-13 a la(s) 07 10 02" src="https://user-images.githubusercontent.com/340766/74425852-21778100-4e33-11ea-8a58-249bd3d50b03.png">
