### PR TITLE
PLANET-4927 Planet 4 Bug Report: Page, Evergreen: Spacing issue when using background image

### DIFF
--- a/src/components/_skip-links.scss
+++ b/src/components/_skip-links.scss
@@ -11,8 +11,8 @@
 //
 // Styleguide Components.skip-links
 .skip-links {
-  margin: 0;
-  padding: 0;
+  margin: 0 !important;
+  padding: 0 !important;
   list-style-type: none;
 
   a {


### PR DESCRIPTION
Added !important to the margin and padding of the _skip-links ul so that it won't push the overlay down
Ref: https://jira.greenpeace.org/browse/PLANET-4927