### PR TITLE
PLANET-4937: Search results post type should use an a tag instead of a button that behaves like an a tag

### DIFF
--- a/src/layout/_breadcrumbs.scss
+++ b/src/layout/_breadcrumbs.scss
@@ -83,6 +83,11 @@
 
     &.page-type {
       text-transform: uppercase;
+      color: $blue;
+
+      &:hover {
+        color: $blue;
+      }
 
       html[dir="rtl"] & {
         text-transform: lowercase;


### PR DESCRIPTION
After the HTML tag change, the link lost its color due to a specificity conflict with the `_reboot` stylesheet.

Ref: https://jira.greenpeace.org/browse/PLANET-4937
