### PR TITLE
PLANET-5000: Rollover color of primary navigation (footer and header) links is wrong

### DIFF
--- a/src/layout/_footer.scss
+++ b/src/layout/_footer.scss
@@ -66,6 +66,10 @@
 
   a {
     color: var(--footer_links_color, inherit);
+
+    &:hover {
+      color: var(--footer_links_color, $spray);
+    }
   }
 
   li {
@@ -189,9 +193,9 @@
 
   a {
     color: var(--footer_links_color, $white);
-    
-    &:hover {	
-      color: var(--footer_links_color, inherit);	
+
+    &:hover {
+      color: var(--footer_links_color, $spray);
     }
   }
 }

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -98,6 +98,10 @@ $navbar-default-height: 60px;
 
   a {
     color: $white;
+
+    &:hover {
+      color: $spray;
+    }
   }
 
   .donate-nav-item {


### PR DESCRIPTION
Hold on: this passed UAT but I've found a conflict with another ticket (PLANET-5001).

Will remove the `!important` rules and rearrange the CSS precedence if needed.

Ref: https://jira.greenpeace.org/browse/PLANET-5000