### PR TITLE
Revert "PLANET-5037 Remove table background colors in spreadsheets"

### DIFF
--- a/src/layout/_tables.scss
+++ b/src/layout/_tables.scss
@@ -14,6 +14,7 @@
     }
 
     th {
+      background-color: $dark-blue;
       color: $white;
       height: 36px;
       font-size: $font-size-xs;
@@ -36,14 +37,8 @@
       }
     }
 
-    // If it's a spreadsheet, the background colors are already set
-    &:not(.spreadsheet-table) th {
-      background-color: $dark-blue;
-    }
-
     // Table having `.has-background` class means that a background color was explicitly set on the block.
-    // If it's a spreadsheet, the background colors are already set
-    &:not(.has-background), &:not(.spreadsheet-table) {
+    &:not(.has-background) {
       tr:nth-child(odd) {
         background-color: $table-odd;
       }


### PR DESCRIPTION
Reverts greenpeace/planet4-styleguide#51

Making the selector more specific with `:not()` could cause issues in downstream css, we'll include another fix in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/270