### PR TITLE
PLANET-5063 Make navbar text link colors more explicit

### DIFF
--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -96,7 +96,7 @@ $navbar-default-height: 60px;
     align-items: center;
   }
 
-  a {
+  a.nav-link {
     color: $white;
 
     &:hover {
@@ -112,7 +112,6 @@ $navbar-default-height: 60px;
   .btn-donate {
     margin-top: 10px;
     height: 40px;
-    color: $grey;
   }
 
   // Move header down when WordPress Admin Bar is present


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5063

This helps to differentiate buttons (eg. Donate) that don't have
a `.nav-link` class and follow another color palette.

Also removed the duplicate color for `.btn-donate`. We already have that
on the buttons component.