### PR TITLE
Planet 5058 - Table background colors

### DIFF
--- a/src/base/_colors.scss
+++ b/src/base/_colors.scss
@@ -187,8 +187,6 @@ $heading:               #004d53;
 $step-number:           #a7a7a7;
 $brown-header:          #5c1f10;
 $single-bg:             #f6f4e7;
-$table-odd:             #f2f2f2;
-$table-even:            #eaeaea;
 
 // Colors to be fixed/addressed:
 $article-heading-color:	#152431;
@@ -201,6 +199,28 @@ $shadow-color:          $grey-60;
 $hover-nav:             #052a30;
 $cookie-bkg:            #c0dbe2;
 $cookie-blue:           #094464;
+
+// Table/spreadsheet colors
+$table-font-color: #020202;
+
+// Background colors
+// Grey variant (default)
+$table-header-grey: #45494c;
+$table-odd-row-grey: #ececec;
+$table-even-row-grey: #f5f7f8;
+$table-footer-grey: #e0e4e7;
+
+// Green variant
+$table-header-green: #073d14;
+$table-odd-row-green: #d0fac9;
+$table-even-row-green: #eafee7;
+$table-footer-green: #d1e8cd;
+
+// Blue variant
+$table-header-blue: #074365;
+$table-odd-row-blue: #c9e7fa;
+$table-even-row-blue: #e7f5fe;
+$table-footer-blue: #c3d7e2;
 
 // Allower colors for blocks palette
 $palette: (

--- a/src/layout/_tables.scss
+++ b/src/layout/_tables.scss
@@ -21,6 +21,9 @@
       font-size: $font-size-xs;
       padding: 6px $n20;
       box-sizing: border-box;
+      @include x-large-and-up {
+        font-size: $font-size-md;
+      }
     }
 
     td {

--- a/src/layout/_tables.scss
+++ b/src/layout/_tables.scss
@@ -16,7 +16,6 @@
     }
 
     th {
-      background-color: $dark-blue;
       color: $white;
       height: 36px;
       font-size: $font-size-xs;
@@ -29,6 +28,7 @@
       font-size: $font-size-xs;
       padding: $n20;
       vertical-align: top;
+      color: $table-font-color;
 
       @include mobile-only {
         min-width: 300px;
@@ -39,14 +39,59 @@
       }
     }
 
-    // Table having `.has-background` class means that a background color was explicitly set on the block.
-    &:not(.has-background) {
+    // Background colors
+    // Grey background (defaut)
+    th {
+      background-color: $table-header-grey;
+    }
+
+    tr:nth-child(odd) {
+      background-color: $table-odd-row-grey;
+    }
+
+    tr:nth-child(even) {
+      background-color: $table-even-row-grey;
+    }
+
+    tfoot td {
+      background-color: $table-footer-grey;
+    }
+
+    // Green background
+    &.has-green-background-color {
+      th {
+        background-color: $table-header-green;
+      }
+
       tr:nth-child(odd) {
-        background-color: $table-odd;
+        background-color: $table-odd-row-green;
       }
 
       tr:nth-child(even) {
-        background-color: $table-even;
+        background-color: $table-even-row-green;
+      }
+
+      tfoot td {
+        background-color: $table-footer-green;
+      }
+    }
+
+    // Blue background
+    &.has-blue-background-color {
+      th {
+        background-color: $table-header-blue;
+      }
+
+      tr:nth-child(odd) {
+        background-color: $table-odd-row-blue;
+      }
+
+      tr:nth-child(even) {
+        background-color: $table-even-row-blue;
+      }
+
+      tfoot td {
+        background-color: $table-footer-blue;
       }
     }
   }

--- a/src/layout/_tables.scss
+++ b/src/layout/_tables.scss
@@ -8,6 +8,8 @@
       overflow: auto;
     }
 
+    thead,
+    tfoot,
     th,
     td {
       border: none;

--- a/src/layout/_tables.scss
+++ b/src/layout/_tables.scss
@@ -38,62 +38,6 @@
         font-size: $font-size-md;
       }
     }
-
-    // Background colors
-    // Grey background (defaut)
-    th {
-      background-color: $table-header-grey;
-    }
-
-    tr:nth-child(odd) {
-      background-color: $table-odd-row-grey;
-    }
-
-    tr:nth-child(even) {
-      background-color: $table-even-row-grey;
-    }
-
-    tfoot td {
-      background-color: $table-footer-grey;
-    }
-
-    // Green background
-    &.has-green-background-color {
-      th {
-        background-color: $table-header-green;
-      }
-
-      tr:nth-child(odd) {
-        background-color: $table-odd-row-green;
-      }
-
-      tr:nth-child(even) {
-        background-color: $table-even-row-green;
-      }
-
-      tfoot td {
-        background-color: $table-footer-green;
-      }
-    }
-
-    // Blue background
-    &.has-blue-background-color {
-      th {
-        background-color: $table-header-blue;
-      }
-
-      tr:nth-child(odd) {
-        background-color: $table-odd-row-blue;
-      }
-
-      tr:nth-child(even) {
-        background-color: $table-even-row-blue;
-      }
-
-      tfoot td {
-        background-color: $table-footer-blue;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5058

We want to offer the same color options for the Table block as we do for the Spreadsheet block. The only difference is that tables also have a footer, which requires an additional color. This PR takes care of 3 things:
- Create the color variables used for both tables and spreadsheets
- Remove background colors set in the `_tables.scss` file as they are now defined in override file in the planet4-plugin-gutenberg-blocks repo (see [this PR]( https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/278))
- Update header font size in bigger screens

See corresponding master-theme PR [here](https://github.com/greenpeace/planet4-master-theme/pull/1093)