### PR TITLE
PLANET-5114 Add css variables for easier child-theme customisation

### DIFF
--- a/src/base/_body.scss
+++ b/src/base/_body.scss
@@ -8,7 +8,7 @@ body {
   font-family: $lora;
   position: relative;
   overflow-y: hidden;
-  background-color: var(--body_background_color, $white);
+  background-color: var(--body-background-color, $white);
 
   &.search {
     font-family: $roboto;

--- a/src/base/_body.scss
+++ b/src/base/_body.scss
@@ -8,7 +8,7 @@ body {
   font-family: $lora;
   position: relative;
   overflow-y: hidden;
-  background-color: $white;
+  background-color: var(--body_background_color, $white);
 
   &.search {
     font-family: $roboto;

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -162,8 +162,8 @@
 
 .btn-donate,
 .wp-block-button.is-style-donate a {
-  background-color: $aquamarine;
-  color: $grey;
+  background-color: var(--btn-donate_background_color, $aquamarine);
+  color: var(--btn-donate_color, $grey);
   font-size: $font-size-sm;
   line-height: 1.65;
   min-width: 180px;
@@ -174,12 +174,12 @@
 
   &:hover,
   &:focus {
-    background-color: $spray;
-    color: $dark-shade-black;
+    background-color: var(--btn-donate_hover_background_color, $spray);
+    color: var(--btn-donate_hover_color, $dark-shade-black);
   }
 
   &:active {
-    background-color: $java-dark;
+    background-color: var(--btn-donate_active_background_color, $java-dark);
   }
 
   @include large-and-up {

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -62,6 +62,7 @@
 .btn-primary,
 .wp-block-button.is-style-cta a {
   background-color: $orange;
+  color: var(--btn-primary-color, $white);
   box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
   &:hover,
@@ -162,8 +163,8 @@
 
 .btn-donate,
 .wp-block-button.is-style-donate a {
-  background-color: var(--btn-donate_background_color, $aquamarine);
-  color: var(--btn-donate_color, $grey);
+  background-color: var(--btn-donate-background-color, $aquamarine);
+  color: var(--btn-donate-color, $grey);
   font-size: $font-size-sm;
   line-height: 1.65;
   min-width: 180px;
@@ -174,12 +175,12 @@
 
   &:hover,
   &:focus {
-    background-color: var(--btn-donate_hover_background_color, $spray);
-    color: var(--btn-donate_hover_color, $dark-shade-black);
+    background-color: var(--btn-donate-hover-background-color, $spray);
+    color: var(--btn-donate-hover-color, $dark-shade-black);
   }
 
   &:active {
-    background-color: var(--btn-donate_active_background_color, $java-dark);
+    background-color: var(--btn-donate-active-background-color, $java-dark);
   }
 
   @include large-and-up {

--- a/src/layout/_footer.scss
+++ b/src/layout/_footer.scss
@@ -68,7 +68,7 @@
     color: var(--footer_links_color, inherit);
 
     &:hover {
-      color: var(--footer_links_color, $spray);
+      color: var(--footer_links_hover_color, $spray);
     }
   }
 

--- a/src/layout/_footer.scss
+++ b/src/layout/_footer.scss
@@ -68,7 +68,7 @@
     color: var(--footer_links_color, inherit);
 
     &:hover {
-      color: var(--footer_links_hover_color, $spray);
+      color: var(--footer_links_color, $spray);
     }
   }
 

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -97,10 +97,11 @@ $navbar-default-height: 60px;
   }
 
   a.nav-link {
-    color: $white;
+    color: var(--nav-link_color, $white);
 
     &:hover {
-      color: $spray;
+      background-color: var(--nav-link_hover_background_color, transparent);
+      color: var(--nav-link_hover_color, $spray);
     }
   }
 
@@ -433,7 +434,7 @@ $navbar-default-height: 60px;
     .nav-link:hover {
       position: relative;
       z-index: 2;
-      color: $spray;
+      color: var(--nav-link_hover_color, $spray);
     }
 
     .active .nav-link::before {
@@ -469,18 +470,18 @@ $navbar-default-height: 60px;
       padding: 0;
       min-width: 20%;
       text-align: center;
-      border-bottom: 2px solid transparent;
+      border-bottom: var(--nav-link_border_width, 2px) solid transparent;
 
       &:hover,
       &:focus,
       &:active {
-        border-bottom: 2px solid $white;
+        border-bottom: var(--nav-link_border_width, 2px) solid var(--nav-link_hover_border_color, $white);
       }
     }
 
     .active .nav-link {
-      color: $spray;
-      border-bottom: 2px solid $spray;
+      color: var(--nav-link_hover_color, $spray);
+      border-bottom: var(--nav-link_border_width, 2px) solid var(--nav-link_active_border_color, $spray);
     }
   }
 

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -97,11 +97,10 @@ $navbar-default-height: 60px;
   }
 
   a.nav-link {
-    color: var(--nav-link_color, $white);
+    color: var(--nav-link-color, $white);
 
     &:hover {
-      background-color: var(--nav-link_hover_background_color, transparent);
-      color: var(--nav-link_hover_color, $spray);
+      color: var(--nav-link-hover-color, $spray);
     }
   }
 
@@ -434,7 +433,7 @@ $navbar-default-height: 60px;
     .nav-link:hover {
       position: relative;
       z-index: 2;
-      color: var(--nav-link_hover_color, $spray);
+      color: var(--nav-link-hover-color, $spray);
     }
 
     .active .nav-link::before {
@@ -470,18 +469,18 @@ $navbar-default-height: 60px;
       padding: 0;
       min-width: 20%;
       text-align: center;
-      border-bottom: var(--nav-link_border_width, 2px) solid transparent;
+      border-bottom: var(--nav-link-border-width, 2px) solid transparent;
 
       &:hover,
       &:focus,
       &:active {
-        border-bottom: var(--nav-link_border_width, 2px) solid var(--nav-link_hover_border_color, $white);
+        border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-hover-border-color, $white);
       }
     }
 
     .active .nav-link {
-      color: var(--nav-link_hover_color, $spray);
-      border-bottom: var(--nav-link_border_width, 2px) solid var(--nav-link_active_border_color, $spray);
+      color: var(--nav-link-hover-color, $spray);
+      border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-active-border-color, $spray);
     }
   }
 


### PR DESCRIPTION
This is a non-exhaustive list of added variables that child-themes could use for easier customisation of Planet4 (see [PLANET-5114](https://jira.greenpeace.org/browse/PLANET-5114) for more details). The ones listed below are already in the code and could be used right away, but maybe they need to be renamed?

#### Campaign colors
- Navigation bar background color: [--campaign_nav_color](https://github.com/greenpeace/planet4-styleguide/blob/master/src/layout/_navbar.scss#L83)
- Footer background color: [--footer_color](https://github.com/greenpeace/planet4-styleguide/blob/master/src/layout/_footer.scss#L47)
- Footer links color: [--footer_links_color](https://github.com/greenpeace/planet4-styleguide/blob/master/src/layout/_footer.scss#L68)

#### Spreadsheet colors
- Spreadsheet header background color: [--spreadsheet-header-background](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/Spreadsheet.scss#L27)
- Spreadsheet even rows background color: [--spreadsheet-even-row-background](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/Spreadsheet.scss#L41)
- Spreadsheet odd rows background color: [--spreadsheet-odd-row-background](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/Spreadsheet.scss#L51)

Corresponding plugin-gutenberg-blocks PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/295
Corresponding master-theme PR: https://github.com/greenpeace/planet4-master-theme/pull/1117
Related ticket: https://jira.greenpeace.org/browse/PLANET-5104