### PR TITLE
PLANET-5014 Prevent the skip-links class from pushing page-content down

### DIFF
--- a/src/components/_skip-links.scss
+++ b/src/components/_skip-links.scss
@@ -11,6 +11,7 @@
 //
 // Styleguide Components.skip-links
 .skip-links {
+  display: block !important;
   margin: 0 !important;
   padding: 0 !important;
   list-style-type: none;


### PR DESCRIPTION
Because of typography changes using a too general css selector the skip-links class was pushing content down on some pages.