### PR TITLE
PLANET-5294: Apply list typography to ordered lists

### DIFF
--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -16,7 +16,7 @@ html {
 //
 // Styleguide Style.typography.paragraphs
 p,
-ul li {
+li {
   hyphens: none;
   font-size: $font-size-sm;
   line-height: 1.6rem;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5294

> the numbered lists ("ol" tag) should follow the same typography rules as bullet lists ("ul" tag)

## Fix

<img width="79" alt="Screenshot 2020-07-23 at 09 17 39" src="https://user-images.githubusercontent.com/617346/88260811-6991ae00-ccc5-11ea-9678-a6d4f74c4d75.png" align="right">


I took off the `ul` selector so that `li` tags would follow these rules, be it in `ol`, `ul` or `menu`.

## Tests

A page with lists is available on test env https://k8s.p4.greenpeace.org/test-phobos/list-test/ .  
Locally, create a page and add bullet list and ordered list, they should have the same font-size and line-height, in the backend and on the frontend.