### PR TITLE
PLANET-5563 Remove from css so we can load in head

### DIFF
--- a/src/base/_fonts.scss
+++ b/src/base/_fonts.scss
@@ -1,6 +1,3 @@
-@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900");
-@import url("https://fonts.googleapis.com/css?family=Lora:400,400i,700&subset=latin-ext");
-
 $font-base-size: 16px;
 
 $font-size-xxs: 0.875rem;


### PR DESCRIPTION
https://jira.greenpeace.org/browse/PLANET-5563

* We need to add a preload tag in the head anyway, so it seems better to
keep both together.
