### PR TITLE
PLANET-5465 Remove empty space at top of page when no header

### DIFF
--- a/src/layout/_page-header.scss
+++ b/src/layout/_page-header.scss
@@ -84,6 +84,7 @@
 
   &.page-header-hidden {
     padding: 0 !important;
+    margin: 0 !important;
   }
 
   .container > *:not(.row) {


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5465

- Broken version: https://k8s.p4.greenpeace.org/test-iocaste/act/join-the-movement-for-clean-air/
- Fixed version: https://k8s.p4.greenpeace.org/test-mars/act/join-the-movement-for-clean-air/