### PR TITLE
PLANET-5465 Remove important to fix campaign pages

### DIFF
--- a/src/layout/_page-header.scss
+++ b/src/layout/_page-header.scss
@@ -84,7 +84,7 @@
 
   &.page-header-hidden {
     padding: 0 !important;
-    margin: 0 !important;
+    margin: 0;
   }
 
   .container > *:not(.row) {


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5465

A fix was previously pushed for this issue using `!important` for the new margin value, but this caused issues in campaign pages so we need to remove it. The fix still works in "normal" pages though 🙂 

- Broken version: https://k8s.p4.greenpeace.org/test-iocaste/act/join-the-movement-for-clean-air/
- Fixed version: https://k8s.p4.greenpeace.org/test-mars/act/join-the-movement-for-clean-air/