### PR TITLE
PLANET-5501 - Consistent styles for buttons

### DIFF
--- a/src/base/_colors.scss
+++ b/src/base/_colors.scss
@@ -76,9 +76,9 @@ $yellow-20: #fff6cd;
 // $orange-active - #cd4525;
 //
 // Styleguide Style.colors.orange
-$orange: #f36d3a;
+$orange: #f36b35;
 $orange-hover: #ee562d;
-$orange-active: #cd4525;
+$orange-active: #dd4a22;
 
 // Various greens:
 $eden:              #0f6459;
@@ -88,7 +88,7 @@ $inch-worm:         #a7e021;
 // Various blues:
 $x-dark-blue:  #042233;
 $dark-blue:    #074365;
-$active-blue:  #01223d;
+$active-blue:  #05324c;
 $spray:        #86eee7;
 $aquamarine:   #68dfde;
 $java:         #1bb6d6;

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -18,10 +18,10 @@
   font-size: 1rem;
   text-align: center;
   text-decoration: none;
-  text-transform: uppercase;
+  text-transform: capitalize;
   color: $white;
-  font-weight: 500;
-  border-radius: 0;
+  font-weight: bold;
+  border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
   line-height: 3;
@@ -171,7 +171,6 @@
   margin: 0;
   padding: 2px $n30;
   box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
-  transition: color background-color font-weight 100ms;
 
   &:hover,
   &:focus {

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -54,11 +54,6 @@
   line-height: 2.8;
 }
 
-.btn-medium {
-  font-size: $font-size-sm;
-  line-height: 3;
-}
-
 .btn-large {
   font-size: $font-size-md;
   line-height: 3.1;

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -92,17 +92,9 @@
   margin-bottom: 40px;
   width: 100%;
 
-  html[dir="rtl"] & {
-    line-height: 2.5;
-  }
-
   @include medium-and-up {
     margin-bottom: 40px;
     width: 50%;
-
-    html[dir="rtl"] & {
-      font-size: $font-size-md;
-    }
   }
 
   @include large-and-up {

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -15,10 +15,9 @@
   display: inline-block;
   position: relative;
   font-family: $roboto;
-  font-size: 1rem;
+  font-size: $font-size-sm;
   text-align: center;
   text-decoration: none;
-  text-transform: capitalize;
   color: $white;
   font-weight: bold;
   border-radius: 4px;
@@ -30,6 +29,7 @@
   transition-property: color, background-color, border-color;
   transition-duration: 150ms;
   transition-timing-function: linear;
+  text-transform: capitalize;
 
   &:hover,
   &:focus,
@@ -42,6 +42,11 @@
   &:disabled {
     opacity: .5;
   }
+}
+
+.btn.text-transform-none,
+.wp-block-button.text-transform-none a {
+  text-transform: none;
 }
 
 .btn-small {
@@ -86,7 +91,6 @@
   border-color: $dark-blue;
   color: $dark-blue;
   box-shadow: none;
-  font-size: $font-size-xxs;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -95,7 +99,6 @@
   padding: 2px $n30;
 
   html[dir="rtl"] & {
-    font-size: $font-size-sm;
     line-height: 2.5;
   }
 
@@ -165,7 +168,6 @@
 .wp-block-button.is-style-donate a {
   background-color: var(--btn-donate-background-color, $aquamarine);
   color: var(--btn-donate-color, $grey);
-  font-size: $font-size-sm;
   line-height: 1.65;
   min-width: 180px;
   margin: 0;

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -91,7 +91,6 @@
   text-overflow: ellipsis;
   margin-bottom: 40px;
   width: 100%;
-  padding: 2px $n30;
 
   html[dir="rtl"] & {
     line-height: 2.5;

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -39,8 +39,11 @@
     outline: none;
   }
 
-  &:disabled {
+  &:disabled,
+  &.disabled,
+  &[disabled] {
     opacity: .5;
+    cursor: default;
   }
 }
 
@@ -71,10 +74,15 @@
     border-color: $orange-hover;
   }
 
-  &:active,
-  &:not(:disabled):not(.disabled):active {
+  &:active {
     background-color: $orange-active;
     border-color: $orange-active;
+  }
+
+  &:disabled,
+  &.disabled,
+  &[disabled] {
+    background-color: $orange;
   }
 }
 
@@ -118,10 +126,16 @@
     color: $white;
   }
 
-  &:active,
-  &:not(:disabled):not(.disabled):active {
+  &:active {
     background-color: $active-blue;
     border-color: $active-blue;
+  }
+
+  &:disabled,
+  &.disabled,
+  &[disabled] {
+    background-color: $white;
+    color: $dark-blue;
   }
 }
 
@@ -168,6 +182,12 @@
 
   &:active {
     background-color: var(--btn-donate-active-background-color, $java-dark);
+  }
+
+  &:disabled,
+  &.disabled,
+  &[disabled] {
+    background-color: var(--btn-donate-background-color, $aquamarine);
   }
 
   @include large-and-up {

--- a/src/layout/_cookies.scss
+++ b/src/layout/_cookies.scss
@@ -73,32 +73,12 @@
   }
 
   .btn {
-    background-color: transparentize($white, .7);
-    border-color: $dark-blue;
-    color: $dark-blue;
     height: 32px;
     line-height: 32px;
     font-size: $font-size-xs;
     width: 100%;
     box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
     margin-bottom: 0;
-
-    &:visited {
-      color: $dark-blue;
-    }
-
-    &:hover,
-    &:focus {
-      background-color: $dark-blue;
-      border-color: $dark-blue;
-      color: $white;
-    }
-
-    &:active,
-    &:not(:disabled):not(.disabled):active {
-      background-color: $active-blue;
-      border-color: $active-blue;
-    }
 
     @include medium-and-up {
       width: 150px;

--- a/src/layout/_cookies.scss
+++ b/src/layout/_cookies.scss
@@ -103,11 +103,5 @@
     @include medium-and-up {
       width: 150px;
     }
-
-    html[dir="rtl"] & {
-      font-size: $font-size-sm;
-      line-height: 2.5;
-      height: auto;
-    }
   }
 }

--- a/src/layout/_cookies.scss
+++ b/src/layout/_cookies.scss
@@ -73,14 +73,32 @@
   }
 
   .btn {
+    background-color: transparentize($white, .7);
+    border-color: $dark-blue;
+    color: $dark-blue;
     height: 32px;
     line-height: 32px;
     font-size: $font-size-xs;
     width: 100%;
     box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
-    background-color: transparentize($white, .2);
     margin-bottom: 0;
-    color: $dark-blue;
+
+    &:visited {
+      color: $dark-blue;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: $dark-blue;
+      border-color: $dark-blue;
+      color: $white;
+    }
+
+    &:active,
+    &:not(:disabled):not(.disabled):active {
+      background-color: $active-blue;
+      border-color: $active-blue;
+    }
 
     @include medium-and-up {
       width: 150px;
@@ -90,12 +108,6 @@
       font-size: $font-size-sm;
       line-height: 2.5;
       height: auto;
-    }
-
-    &:hover {
-      color: $white;
-      border-color: $dark-blue;
-      background-color: $dark-blue;
     }
   }
 }

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -40,7 +40,7 @@
 //     <a class="nav-link" href="#">ABOUT US</a>
 //   </li>
 //   <li class="nav-item">
-//     <a class="btn btn-donate" href="#">DONATE</a>
+//     <a class="btn btn-donate" href="#">Donate</a>
 //   </li>
 // </ul>
 // <button


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5501

- Apply 4px radius to all button styles
- Use Roboto and font-weight bold
- Use `text-transform: capitalize`
- Add a `text-transform-none` class
- Primary button background color is changing to #F36B35
- Cookies button should follow secondary button styles
- Remove `btn-medium` class as it just duplicates the "regular" button styles
- Remove some of the RTL-related overrides

#### Related PRs
- [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1205)
- [gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/413)