### PR TITLE
PLANET-5644 Remove text transform on buttons

### DIFF
--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -29,7 +29,6 @@
   transition-property: color, background-color, border-color;
   transition-duration: 150ms;
   transition-timing-function: linear;
-  text-transform: capitalize;
 
   &:hover,
   &:focus,
@@ -45,11 +44,6 @@
     opacity: .5;
     cursor: default;
   }
-}
-
-.btn.text-transform-none,
-.wp-block-button.text-transform-none a {
-  text-transform: none;
 }
 
 .btn-small {
@@ -173,6 +167,7 @@
   margin: 0;
   padding: 2px $n30;
   box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  text-transform: none;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5644
We need to enforce `text-transform: none;` for the donate button, since otherwise it takes the `text-transform: uppercase` applied to the `.top-navigation` class ([here](https://github.com/greenpeace/planet4-styleguide/blob/master/src/layout/_navbar.scss#L78))

#### Testing
See the fixed version here: https://www-dev.greenpeace.org/test-jupiter/

#### Related PRs:
- master-theme: https://github.com/greenpeace/planet4-master-theme/pull/1224
- gutenberg-blocks: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/426