### PR TITLE
PLANET-5368: Fix H3/H4 font sizes on mobile

### DIFF
--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -87,11 +87,19 @@ h3 {
 }
 
 h4 {
-  font-size: 1.5rem;
+  font-size: $font-size-md;
+
+  @include medium-and-up {
+    font-size: $font-size-lg;
+  }
 }
 
 h5 {
-  font-size: $font-size-md;
+  font-size: $font-size-sm;
+
+  @include medium-and-up {
+    font-size: $font-size-md;
+  }
 }
 
 h6 {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5368

> At the moment H3 (1.375rem) is smaller than H4 (1.5rem) on mobile. 

Review of heading size based on ticket recommendations.

- On mobile size: h4 and h5 are downsized
- On regular screen size: h4 is downsized

| | Before fix | After fix |
| --- | --- | --- |
| mobile | ![Screenshot from 2020-11-25 19-22-04](https://user-images.githubusercontent.com/617346/100269494-ed4ef600-2f56-11eb-91ee-e014ae5cd4d7.png) | ![Screenshot from 2020-11-25 19-30-48](https://user-images.githubusercontent.com/617346/100269523-f6d85e00-2f56-11eb-9fc5-ff1a0bec0a8f.png) |
| regular | ![Screenshot from 2020-11-25 19-36-21](https://user-images.githubusercontent.com/617346/100269597-17081d00-2f57-11eb-9fd9-47a5d1b3a219.png) | ![Screenshot from 2020-11-25 19-35-41](https://user-images.githubusercontent.com/617346/100269613-1cfdfe00-2f57-11eb-8d0f-8f10685bf883.png) |


## Fix 

Following [the ticket](https://jira.greenpeace.org/browse/PLANET-5368):
| Heading | size | var | mobile size | mobile var |
| --- | --- | --- | --- | --- |
| H1 | 4rem |  $font-size-xxxxl | 2.5rem | $font-size-xxl |
| H2 | 2.5rem | $font-size-xxl | 1.75rem | $font-size-xl |
| H3 | 1.75rem | $font-size-xl | 1.375rem | $font-size-lg |
| H4 | 1.375rem | $font-size-lg | 1.25rem | $font-size-md |
| H5 | 1.25rem | $font-size-md | 1rem | $font-size-sm |
| H6 | 1rem |  $font-size-sm | 1rem | $font-size-sm |


## Test

- Write a post with many `Heading` blocks :grin: 