### PR TITLE
PLANET-5622: Skewed overlay changes position when page length changes

### DIFF
--- a/src/layout/_skewed-overlay.scss
+++ b/src/layout/_skewed-overlay.scss
@@ -1,6 +1,6 @@
 .skewed-overlay {
   pointer-events: none;
-  height: 100%;
+  height: 200vh;
 
   width: 100%;
   position: absolute;


### PR DESCRIPTION
The Skewed Overlay goes in tandem with the `::after` pseudo element of the `page-header-background` class. 

If we see it as layers, it goes like this, from bottom to top:

```
.page-header-background img -> the background image
::after -> it's a gradient mask from top to bottom, fades the image to bottom
skewed-overlay -> a diagonal overlay on top of the mask
```

The height of the mask depends on the height of the image. The height of the skewed overlay depends on the height of the page so it varies if content is added to the page, for example, when clicking a "Load more" button in an articles block. When the page height changes, the overlay moves a bit to the side, which is a bit costly in slow devices.

We'll talk about these elements in relation to the page background in design meetings, but for now, using a fixed 
height in the `skewed-overlay` fixes the issue. 

I made it `200vh` so it's 2 times the screen height. In most cases a page will be larger than that, but even if it's shorter, as it's a fixed value, the skewed overlay won't move if the page height changes.

Ref: https://jira.greenpeace.org/browse/PLANET-5622