### PR TITLE
PLANET-5980 Fix inconsistencies between editor and frontend

### DIFF
--- a/src/base/_icons.scss
+++ b/src/base/_icons.scss
@@ -119,18 +119,10 @@ a.external-link {
     &:hover::before {
       background-color: transparentize($grey-80, 0.2);
     }
-
-    &:hover.pdf-link.has-text-color.has-grey-80-color::before {
-      background-color: $grey-80;
-    }
-
-    &:hover.pdf-link.has-text-color::before {
-      background-color: $white;
-    }
   }
 
   // Button block, text color manually set
-  .wp-block-button.has-text-color {
+  .wp-block-button a.has-text-color.pdf-link {
     &::before,
     &:hover::before {
       background-color: $white;

--- a/src/base/_icons.scss
+++ b/src/base/_icons.scss
@@ -119,6 +119,29 @@ a.external-link {
     &:hover::before {
       background-color: transparentize($grey-80, 0.2);
     }
+
+    &:hover.pdf-link.has-text-color.has-grey-80-color::before {
+      background-color: $grey-80;
+    }
+
+    &:hover.pdf-link.has-text-color::before {
+      background-color: $white;
+    }
+  }
+
+  // Button block, text color manually set
+  .wp-block-button.has-text-color {
+    &::before,
+    &:hover::before {
+      background-color: $white;
+    }
+
+    &.has-grey-80-color {
+      &::before,
+      &:hover::before {
+        background-color: $grey-80;
+      }
+    }
   }
 
   a.external-link {

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -48,6 +48,12 @@ h5,
 h6 {
   font-family: $roboto;
   font-weight: bold;
+
+  &.has-text-align-center,
+  &.has-text-align-right,
+  &.has-text-align-left {
+    width: 100%;
+  }
 }
 
 h1 {

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -44,6 +44,20 @@
     opacity: .5;
     cursor: default;
   }
+
+  &.has-background {
+    border-color: transparent !important;
+  }
+
+  &.has-grey-80-color {
+    color: $grey-80 !important;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: $grey-80 !important;
+    }
+  }
 }
 
 .btn-small {

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -101,23 +101,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 40px;
-  width: 100%;
-
-  @include medium-and-up {
-    margin-bottom: 40px;
-    width: 50%;
-  }
-
-  @include large-and-up {
-    margin-bottom: 0;
-    width: 80%;
-  }
-
-  @include x-large-and-up {
-    margin-bottom: 0;
-    width: 60%;
-  }
 
   &:visited {
     color: $dark-blue;


### PR DESCRIPTION
### Description

See [PLANET-5980](https://jira.greenpeace.org/browse/PLANET-5980)

- Header alignment choice (left/right/center) not reflected in the frontend
- Image alignment breaks text and creates gaps
- Button manually chosen text color not applied properly in the frontend

Should also solve [PLANET-5857](https://jira.greenpeace.org/browse/PLANET-5857)
- Weird breaks in paragraphs and lists with HTML tags (bold, anchor links, etc)

### Related PRs
- [gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/519)