### PR TITLE
PLANET-5981 Updates for Bootstrap 5

### DIFF
--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -110,19 +110,6 @@ h6 {
   color: $white;
 }
 
-.screen-reader-text {
-  border: 0;
-  clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal !important;
-}
-
 // Links
 //
 // Link elements `<a>`.

--- a/src/layout/_forms.scss
+++ b/src/layout/_forms.scss
@@ -143,7 +143,8 @@
   }
 }
 
-.form-control {
+.form-control,
+.form-select {
   border-radius: 4px;
   font-family: $roboto;
   background-color: $white;
@@ -175,7 +176,7 @@ input[type="email"].form-control {
   padding: 11px 16px;
 }
 
-select.form-control {
+.form-select {
   height: 48px;
 
   &:invalid {

--- a/src/layout/_forms.scss
+++ b/src/layout/_forms.scss
@@ -192,29 +192,33 @@ textarea.form-control {
   resize: none;
 }
 
-.form-group.animated-label {
-  position: relative;
+.form-group {
+  margin-bottom: 1rem;
 
-  label {
-    position: absolute;
-    left: 0;
-    top: 16px;
-    font-weight: 500;
-    color: $grey-40;
-    padding-inline-start: 16px;
-    font-size: 11px;
-    font-family: $roboto;
-    opacity: 0;
-    transition: all .3s ease;
-    margin-bottom: 0;
-  }
+  &.animated-label {
+    position: relative;
 
-  .form-control:not(:placeholder-shown) {
-    padding: 18px 16px 4px 16px;
+    label {
+      position: absolute;
+      left: 0;
+      top: 16px;
+      font-weight: 500;
+      color: $grey-40;
+      padding-inline-start: 16px;
+      font-size: 11px;
+      font-family: $roboto;
+      opacity: 0;
+      transition: all .3s ease;
+      margin-bottom: 0;
+    }
 
-    & ~ label {
-      transform: translateY(-10px);
-      opacity: 1;
+    .form-control:not(:placeholder-shown) {
+      padding: 18px 16px 4px 16px;
+
+      & ~ label {
+        transform: translateY(-10px);
+        opacity: 1;
+      }
     }
   }
 }

--- a/src/layout/_forms.scss
+++ b/src/layout/_forms.scss
@@ -179,6 +179,10 @@ input[type="email"].form-control {
 .form-select {
   height: 48px;
 
+  html[dir="rtl"] & {
+    background-position: left 0.75rem center;
+  }
+
   &:invalid {
     color: $grey-40;
   }

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -172,16 +172,11 @@ $navbar-default-height: 60px;
     height: 100%;
     top: 0;
     left: 0;
-
     outline: 0;
     border: 0;
     box-shadow: none;
     padding: 0;
     margin: 0;
-
-    span {
-      @extend .screen-reader-text;
-    }
   }
 
   @include large-and-up {


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5981

Changes made to comply with the [migration doc](https://getbootstrap.com/docs/5.0/migration/):
- Add margin-bottom to the `form-group` class
- Add `form-select` to select components instead of `form-control` (which now has `appearance: none;` hiding the select's arrow) + add small fix for rtl direction

Additional clean-up:
- Remove `screen-reader-text` class to use Bootstrap's `visually-hidden` instead

### Testing

You can check the changes on [this test instance](https://www-dev.greenpeace.org/test-janus/), basically everything should look/behave the same as it does in the current sites 🙂 

### Related PRs

- [gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/521)
- [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1323)