### PR TITLE
Add variables to replace campaign overrides

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -64,7 +64,9 @@
     "selector-pseudo-class-case": "lower",
     "selector-pseudo-element-case": "lower",
     "selector-type-case": "lower",
-    "selector-type-no-unknown": true,
+    "selector-type-no-unknown": [true, {
+      "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/", "_--", "lite-youtube"]
+    }],
     "selector-max-empty-lines": 0,
 
     "rule-empty-line-before": ["always", {"except": ["first-nested", "after-single-line-comment"]}],

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Greenpeace Planet 4 Styleguide
 
 ![Planet4](./planet4.png)
+
+This uses [dashdash](https://github.com/greenpeace/planet4-dashdash) as a shorthand for writing properties that are
+exposed as custom properties. Please refer to the readme of that repository for a description of the syntax.

--- a/src/base/_body.scss
+++ b/src/base/_body.scss
@@ -6,11 +6,14 @@ body {
 }
 
 body {
-  color: $grey-80;
-  font-family: $lora;
+  _-- {
+    color: $grey-80;
+    font-family: $lora;
+    background-color: $white;
+  }
+
   position: relative;
   overflow-y: hidden;
-  background-color: var(--body-background-color, $white);
 
   &.search {
     font-family: $roboto;

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -51,7 +51,7 @@ h3,
 h4,
 h5,
 h6 {
-  --headers-- {
+  --headings-- {
     font-family: $roboto;
     font-weight: bold;
   }

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -18,12 +18,17 @@ html {
 p,
 li {
   hyphens: none;
-  font-size: $font-size-sm;
-  line-height: 1.6rem;
+
+  --text--medium-down-- {
+    font-size: $font-size-sm;
+    line-height: 1.6rem;
+  }
 
   @include x-large-and-up {
-    font-size: $font-size-md;
-    line-height: 1.75rem;
+    --text--large-up-- {
+      font-size: $font-size-md;
+      line-height: 1.75rem;
+    }
   }
 }
 
@@ -46,8 +51,10 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $roboto;
-  font-weight: bold;
+  --headers-- {
+    font-family: $roboto;
+    font-weight: bold;
+  }
 }
 
 h1 {
@@ -134,8 +141,15 @@ h6 {
 //
 // Styleguide Style.typography.links
 a {
-  color: var(--link--color, $link-color);
-  text-decoration: none;
+  --link-- {
+    color: $link-color;
+    text-decoration: none;
+
+    &:hover {
+      color: $link-color;
+      text-decoration: underline;
+    }
+  }
 
   &.external-link {
     .external-icon {
@@ -150,10 +164,5 @@ a {
         transform: scaleX(-1);
       }
     }
-  }
-
-  &:hover {
-    color: var(--link-hover--color, $link-color);
-    text-decoration: underline;
   }
 }

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -12,19 +12,20 @@
 .btn,
 .wp-block-button a,
 .wp-block-file .wp-block-file__button {
+  --button-- {
+    font-family: $roboto;
+    font-size: $font-size-sm;
+    font-weight: bold;
+    border-radius: 4px;
+    padding: 0 30px;
+    line-height: 3;
+  }
   display: inline-block;
   position: relative;
-  font-family: $roboto;
-  font-size: $font-size-sm;
   text-align: center;
   text-decoration: none;
-  color: $white;
-  font-weight: bold;
-  border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
-  line-height: 3;
-  padding: 0 $n30;
   appearance: none;
   transition-property: color, background-color, border-color;
   transition-duration: 150ms;
@@ -56,23 +57,31 @@
   line-height: 3.1;
 }
 
+$primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+
 .btn-primary,
 .wp-block-button.is-style-cta a {
-  background-color: $orange;
-  color: var(--btn-primary-color, $white);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
-
-  &:hover,
-  &:focus,
-  &:active {
-    background-color: $orange-hover;
-    border-color: $orange-hover;
-  }
-
-  &:disabled,
-  &.disabled,
-  &[disabled] {
+  --button-primary-- {
     background-color: $orange;
+    color: $white;
+    border-color: transparent;
+    box-shadow: $primary-button-box-shadow;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background-color: $orange-hover;
+      border-color: $orange-hover;
+      box-shadow: $primary-button-box-shadow;
+    }
+
+    &:disabled,
+    &.disabled,
+    &[disabled] {
+      background-color: $orange;
+      border-color: transparent;
+      box-shadow: $primary-button-box-shadow;
+    }
   }
 }
 
@@ -80,14 +89,40 @@
 .wp-block-button.is-style-secondary a,
 [class="wp-block-button"] a,
 .wp-block-file .wp-block-file__button {
-  background-color: transparentize($white, .7);
-  border-color: $dark-blue;
-  color: $dark-blue;
-  box-shadow: none;
+  --button-secondary-- {
+    background-color: transparentize($white, .7);
+    border-color: $dark-blue;
+    color: $dark-blue;
+    box-shadow: none;
+    margin-bottom: 40px;
+
+    &:visited {
+      color: $dark-blue;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: $dark-blue;
+      border-color: $dark-blue;
+      color: $white;
+    }
+
+    &:active {
+      background-color: $active-blue;
+      border-color: $active-blue;
+    }
+
+    &:disabled,
+    &.disabled,
+    &[disabled] {
+      background-color: $white;
+      color: $dark-blue;
+      border-color: $dark-blue;
+    }
+  }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 40px;
   width: 100%;
 
   @include medium-and-up {
@@ -103,29 +138,6 @@
   @include x-large-and-up {
     margin-bottom: 0;
     width: 60%;
-  }
-
-  &:visited {
-    color: $dark-blue;
-  }
-
-  &:hover,
-  &:focus {
-    background-color: $dark-blue;
-    border-color: $dark-blue;
-    color: $white;
-  }
-
-  &:active {
-    background-color: $active-blue;
-    border-color: $active-blue;
-  }
-
-  &:disabled,
-  &.disabled,
-  &[disabled] {
-    background-color: $white;
-    color: $dark-blue;
   }
 }
 
@@ -156,19 +168,21 @@
 
 .btn-donate,
 .wp-block-button.is-style-donate a {
-  background-color: var(--btn-donate-background-color, $aquamarine);
-  color: var(--btn-donate-color, $grey-80);
+  --button-donate-- {
+    background: $aquamarine;
+    color: $grey-80;
+    min-width: 180px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+
+    &:hover,
+    &:focus {
+      color: transparentize($grey-80, 0.2);
+    }
+  }
   line-height: 1.65;
-  min-width: 180px;
   margin: 0;
   padding: 2px $n30;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   text-transform: none;
-
-  &:hover,
-  &:focus {
-    color: transparentize($grey-80, 0.2);
-  }
 
   @include large-and-up {
     font-size: $font-size-md;

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -173,10 +173,13 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     color: $grey-80;
     min-width: 180px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+    border-width: 1px;
+    border-color: transparent;
 
     &:hover,
     &:focus {
       color: transparentize($grey-80, 0.2);
+      background: var(--button-donate--background-color, $aquamarine);
     }
   }
   line-height: 1.65;

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -19,6 +19,9 @@
     border-radius: 4px;
     padding: 0 30px;
     line-height: 3;
+    transition-property: color, background-color, border-color;
+    transition-duration: 150ms;
+    transition-timing-function: linear;
   }
   display: inline-block;
   position: relative;
@@ -27,9 +30,6 @@
   border: 1px solid transparent;
   cursor: pointer;
   appearance: none;
-  transition-property: color, background-color, border-color;
-  transition-duration: 150ms;
-  transition-timing-function: linear;
 
   &:hover,
   &:focus,
@@ -62,7 +62,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 .btn-primary,
 .wp-block-button.is-style-cta a {
   --button-primary-- {
-    background-color: $orange;
+    background: $orange;
     color: $white;
     border-color: transparent;
     box-shadow: $primary-button-box-shadow;
@@ -70,7 +70,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     &:hover,
     &:focus,
     &:active {
-      background-color: $orange-hover;
+      background: $orange-hover;
       border-color: $orange-hover;
       box-shadow: $primary-button-box-shadow;
     }
@@ -78,7 +78,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     &:disabled,
     &.disabled,
     &[disabled] {
-      background-color: $orange;
+      background: $orange;
       border-color: transparent;
       box-shadow: $primary-button-box-shadow;
     }
@@ -90,7 +90,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 [class="wp-block-button"] a,
 .wp-block-file .wp-block-file__button {
   --button-secondary-- {
-    background-color: transparentize($white, .7);
+    background: transparentize($white, .7);
     border-color: $dark-blue;
     color: $dark-blue;
     box-shadow: none;
@@ -102,20 +102,20 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
     &:hover,
     &:focus {
-      background-color: $dark-blue;
+      background: $dark-blue;
       border-color: $dark-blue;
       color: $white;
     }
 
     &:active {
-      background-color: $active-blue;
+      background: $active-blue;
       border-color: $active-blue;
     }
 
     &:disabled,
     &.disabled,
     &[disabled] {
-      background-color: $white;
+      background: $white;
       color: $dark-blue;
       border-color: $dark-blue;
     }

--- a/src/layout/_footer.scss
+++ b/src/layout/_footer.scss
@@ -243,9 +243,6 @@
   line-height: 1;
 
   .footer-social-media {
-    _-- {
-      color: $grey-20;
-    }
     font-size: $font-size-xl;
     margin: 0 auto $space-md auto;
     text-align: center;
@@ -265,10 +262,6 @@
 
     a {
       transition: color 100ms linear;
-
-      &:hover {
-        color: $grey-20;
-      }
     }
 
     .list-unstyled {
@@ -277,9 +270,6 @@
   }
 
   .gp-year {
-    _-- {
-      color: $white;
-    }
     font-size: $font-size-xxs;
     font-family: $lora;
     margin: 40px 0 30px 0;

--- a/src/layout/_footer.scss
+++ b/src/layout/_footer.scss
@@ -219,7 +219,9 @@
 }
 
 .gp-year {
-  color: var(--footer_links_color, $white);
+  --footer--copyright--year-- {
+    color: $white;
+  }
   font-size: $font-size-xxs;
   text-transform: none;
 
@@ -241,7 +243,9 @@
   line-height: 1;
 
   .footer-social-media {
-    color: var(--footer_links_color, $grey-20);
+    _-- {
+      color: $grey-20;
+    }
     font-size: $font-size-xl;
     margin: 0 auto $space-md auto;
     text-align: center;
@@ -273,13 +277,15 @@
   }
 
   .gp-year {
-    color: var(--footer_links_color, $white);
+    _-- {
+      color: $white;
+    }
     font-size: $font-size-xxs;
     font-family: $lora;
     margin: 40px 0 30px 0;
   }
 
-  .icon {
-    fill: var(--footer_links_color, $white);
+  .icon _-- {
+    fill: $white;
   }
 }

--- a/src/layout/_footer.scss
+++ b/src/layout/_footer.scss
@@ -42,9 +42,11 @@
 //
 // Styleguide Layout.footer
 .site-footer {
-  font-family: $roboto;
+  --footer-- {
+    font-family: $roboto;
+    background: $dark-blue;
+  }
   padding: 45px 0 $n25;
-  background: var(--footer_color, $dark-blue);
   position: relative;
   z-index: 2;
   text-align: center;
@@ -60,15 +62,11 @@
     padding: 55px 0 $n25;
   }
 
-  p {
-    font-family: $roboto;
-  }
-
-  a {
-    color: var(--footer_links_color, inherit);
+  a --footer--links-- {
+    color: inherit;
 
     &:hover {
-      color: var(--footer_links_color, $white);
+      color: $white;
     }
   }
 
@@ -78,7 +76,13 @@
 }
 
 .footer-social-media {
-  color: var(--footer_links_color, $grey-20);
+  _-- {
+    color: $grey-20;
+
+    &:hover {
+      color: $white;
+    }
+  }
   font-size: $font-size-xl;
   margin: auto;
   text-align: center;
@@ -113,10 +117,6 @@
 
   a {
     transition: color 100ms linear;
-
-    &:hover {
-      color: $white;
-    }
   }
 }
 
@@ -147,10 +147,12 @@
 }
 
 .footer-links {
-  color: var(--footer_links_color, $white);
-  font-weight: bold;
-  text-transform: uppercase;
-  margin-bottom: 16px;
+  _-- {
+    color: $white;
+    font-weight: bold;
+    text-transform: uppercase;
+    margin-bottom: 16px;
+  }
 
   li {
     font-size: $font-size-md;
@@ -167,9 +169,11 @@
 }
 
 .footer-links-secondary {
-  color: var(--footer_links_color, $grey-10);
-  text-transform: uppercase;
-  margin-bottom: 30px;
+  _-- {
+    color: $grey-10;
+    text-transform: uppercase;
+    margin-bottom: 30px;
+  }
 
   @include medium-and-up {
     font-size: $font-size-xxs;
@@ -181,7 +185,9 @@
 }
 
 .copyright-text {
-  color: var(--footer_links_color, $grey-10);
+  --footer--copyright-- {
+    color: $grey-10;
+  }
   font: $font-size-xxs;
   line-height: 1.3;
   margin-left: auto;
@@ -207,8 +213,8 @@
     }
   }
 
-  a {
-    color: var(--footer_links_color, $white);
+  a --footer--copyright--link-- {
+    color: $white;
   }
 }
 

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -70,6 +70,9 @@ $min-height: 40px;
 $navbar-default-height: 60px;
 
 .top-navigation {
+  _-- {
+    background: transparentize($dark-blue, 0.2);
+  }
   position: fixed;
   width: 100%;
   top: 0;
@@ -80,7 +83,6 @@ $navbar-default-height: 60px;
   flex-direction: row;
   justify-content: space-between;
   align-items: normal;
-  background: var(--campaign_nav_color, transparentize($dark-blue, 0.2));
   height: $menu-height-small;
   font-family: $roboto;
 

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -72,7 +72,10 @@ $navbar-default-height: 60px;
 .top-navigation {
   _-- {
     background: transparentize($dark-blue, 0.2);
+    border-bottom-width: 0;
+    border-bottom-color: transparent;
   }
+  border-bottom-style: solid;
   position: fixed;
   width: 100%;
   top: 0;

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -786,7 +786,9 @@ $navbar-default-height: 60px;
 }
 
 .navigation-bar_min {
-  height: $min-height;
+  --top-navigation-min-- {
+    height: $min-height;
+  }
   align-items: baseline;
   justify-content: start;
 

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -74,6 +74,7 @@ $navbar-default-height: 60px;
     background: transparentize($dark-blue, 0.2);
     border-bottom-width: 0;
     border-bottom-color: transparent;
+    box-shadow: none;
   }
   border-bottom-style: solid;
   position: fixed;
@@ -102,7 +103,13 @@ $navbar-default-height: 60px;
   }
 
   a.nav-link {
-    color: var(--nav-link-color, $white);
+    --nav-link-- {
+      color: $white;
+
+      &:hover {
+        color: $white;
+      }
+    }
   }
 
   .donate-nav-item {
@@ -466,20 +473,25 @@ $navbar-default-height: 60px;
     }
 
     .nav-link {
-      padding: 0;
-      min-width: 20%;
-      text-align: center;
-      border-bottom: var(--nav-link-border-width, 2px) solid transparent;
+      border-bottom-style: solid;
 
-      &:hover,
-      &:focus,
-      &:active {
-        border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-hover-border-color, $white);
+      --nav-link--large-up-- {
+        border-bottom-width: 2px;
+        border-bottom-color: transparent;
+        min-width: 20%;
+
+        &:hover,
+        &:focus,
+        &:active {
+          border-bottom-color: $white;
+        }
       }
+      padding: 0;
+      text-align: center;
     }
 
     .active .nav-link {
-      border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-active-border-color, $white);
+      border-bottom-color: $white;
     }
   }
 

--- a/src/layout/_navbar.scss
+++ b/src/layout/_navbar.scss
@@ -628,10 +628,12 @@ $navbar-default-height: 60px;
 }
 
 .country-list {
+  _-- {
+    background: $x-dark-blue;
+    line-height: 1.5;
+  }
   display: none;
   text-transform: none;
-  background: $x-dark-blue;
-  line-height: 1.5;
   padding: 1.4em 0;
   overflow-y: hidden;
   top: $navbar-default-height;
@@ -721,14 +723,15 @@ $navbar-default-height: 60px;
   }
 
   @include large-and-up {
+    --country-list--large-up-- {
+      height: 344px;
+      width: 80%;
+      left: 10%;
+    }
+    max-height: calc(100vh - #{$menu-height-large});
     position: absolute;
-    height: 344px;
-    width: 80%;
-    left: 10%;
     overflow-x: hidden;
     overflow-y: hidden !important;
-    max-height: 344px;
-    max-height: calc(100vh - #{$menu-height-large});
     padding: 2em 4em 4em;
 
     .admin-bar & {

--- a/src/layout/_skewed-overlay.scss
+++ b/src/layout/_skewed-overlay.scss
@@ -1,4 +1,7 @@
 .skewed-overlay {
+  _-- {
+    display: block;
+  }
   pointer-events: none;
   height: 100%;
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983
---

Easier to review [with whitespace changes ignored](https://github.com/greenpeace/planet4-styleguide/pull/105/files?diff=split&w=1).

This adds variables for most things that are customized in the current themes. There's only a few cases where I needed to change the CSS logic (background instead of background-color for buttons, include display:block for skewed overlay).
